### PR TITLE
OPFF on main improvements

### DIFF
--- a/smashline-macro/src/callbacks.rs
+++ b/smashline-macro/src/callbacks.rs
@@ -61,7 +61,8 @@ fn generate_agent_main_install_fn(attrs: &AgentFrameAttrs, usr_fn_name: &syn::Id
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
-                    use smash::{L2CFighterBase, L2CValue};
+                    use smash::lua2cpp::L2CFighterBase;
+                    use smash::lib::L2CValue;
                     use std::mem::transmute;
                     let usr_fn_name: extern "C" fn(&mut L2CFighterBase) -> L2CValue = transmute(#usr_fn_name as *const ());
                     smashline::replace_agent_frame_main(#agent, #is_fighter, Some(&mut #orig_name), usr_fn_name);
@@ -225,7 +226,8 @@ pub fn agent_frame_callback(attrs: TokenStream, input: TokenStream, is_fighter: 
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
-                    use smash::{L2CFighterBase, L2CValue};
+                    use smash::lua2cpp::L2CFighterBase;
+                    use smash::lib::L2CValue;
                     use std::mem::transmute;
                     let usr_fn_name: fn(&mut L2CFighterBase) = transmute(#usr_fn_name as *const ());
                     smashline::add_agent_frame_main_callback(usr_fn_name);

--- a/smashline-macro/src/callbacks.rs
+++ b/smashline-macro/src/callbacks.rs
@@ -61,8 +61,7 @@ fn generate_agent_main_install_fn(attrs: &AgentFrameAttrs, usr_fn_name: &syn::Id
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
-                    use smash::lua2cpp::L2CFighterBase;
-                    use smash::lib::L2CValue;
+                    use smash::{lua2cpp::L2CFighterBase, lib::L2CValue};
                     use std::mem::transmute;
                     let usr_fn_name: extern "C" fn(&mut L2CFighterBase) -> L2CValue = transmute(#usr_fn_name as *const ());
                     smashline::replace_agent_frame_main(#agent, #is_fighter, Some(&mut #orig_name), usr_fn_name);
@@ -226,8 +225,7 @@ pub fn agent_frame_callback(attrs: TokenStream, input: TokenStream, is_fighter: 
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
-                    use smash::lua2cpp::L2CFighterBase;
-                    use smash::lib::L2CValue;
+                    use smash::{lua2cpp::L2CFighterBase, lib::L2CValue};
                     use std::mem::transmute;
                     let usr_fn_name: fn(&mut L2CFighterBase) = transmute(#usr_fn_name as *const ());
                     smashline::add_agent_frame_main_callback(usr_fn_name);

--- a/smashline-macro/src/callbacks.rs
+++ b/smashline-macro/src/callbacks.rs
@@ -61,6 +61,7 @@ fn generate_agent_main_install_fn(attrs: &AgentFrameAttrs, usr_fn_name: &syn::Id
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
+                    use smash::{L2CFighterBase, L2CValue};
                     use std::mem::transmute;
                     let usr_fn_name: extern "C" fn(&mut L2CFighterBase) -> L2CValue = transmute(#usr_fn_name as *const ());
                     smashline::replace_agent_frame_main(#agent, #is_fighter, Some(&mut #orig_name), usr_fn_name);
@@ -139,24 +140,6 @@ pub fn agent_frame(attrs: TokenStream, input: TokenStream, is_fighter: bool) -> 
         usr_fn.block.stmts.insert(1, parse_quote! {
             let original_result = original!(#(#args_names),*);
         });
-        if is_fighter {
-            usr_fn.block.stmts.insert(2, parse_quote! {
-                unsafe {
-                    if StatusModule::is_changing(fighter.module_accessor) {
-                        return original_result;
-                    }
-                }
-            });
-        }
-        else {
-            usr_fn.block.stmts.insert(2, parse_quote! {
-                unsafe {
-                    if StatusModule::is_changing(weapon.module_accessor) {
-                        return original_result;
-                    }
-                }
-            });
-        }
         usr_fn.block.stmts.push(parse_quote! {
             return original_result;
         });
@@ -242,6 +225,7 @@ pub fn agent_frame_callback(attrs: TokenStream, input: TokenStream, is_fighter: 
             #[allow(non_snake_case)]
             pub fn #install_name() {
                 unsafe {
+                    use smash::{L2CFighterBase, L2CValue};
                     use std::mem::transmute;
                     let usr_fn_name: fn(&mut L2CFighterBase) = transmute(#usr_fn_name as *const ());
                     smashline::add_agent_frame_main_callback(usr_fn_name);


### PR DESCRIPTION
Change default behavior of main-status-hooked OPFF so that it no longer returns on `StatusModule::is_changing`.

Also imports L2CFighterBase and L2CValue on macro side.